### PR TITLE
fix snapshot resolver in scripted tests

### DIFF
--- a/src/sbt-test/sbt-openapi-generator/simple/build.sbt
+++ b/src/sbt-test/sbt-openapi-generator/simple/build.sbt
@@ -1,8 +1,9 @@
 scalaVersion := "2.12.10"
 
-enablePlugins(OpenApiGeneratorPlugin)
+externalResolvers += Resolver.sonatypeRepo("snapshots")
 
 lazy val generated = project.in(file("generated"))
+  .enablePlugins(OpenApiGeneratorPlugin)
   .settings(
     openApiInputSpec := "openapi.yaml",
     openApiConfigFile := "config.yaml",


### PR DESCRIPTION
That will fix problem when scripted tests trying to retrieve `openapi-generator` snapshot version
Snapshot resolver was missed