### PR TITLE
rename system properties to global properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ sbt generated/openApiGenerate
 | openApiOutputDir| `String` | The output target directory into which code will be generated |
 | openApiConfigFile **| `String` | Path to json configuration file<br> This setting is required with `generatorName` and `inputSpec` settings provided if sbt settings `openApiGeneratorName` and `openApiInputSpec` are absent |
 | openApiAdditionalProperties | `Map[String, String]` | Sets additional properties that can be referenced by the mustache templates in the format of name=value,name=value. You can also have multiple occurrences of this option |
-| openApiSystemProperties | `Map[String, String]` |Sets specified system properties |
+| openApiGlobalProperties | `Map[String, String]` |Sets specified system properties |
 | openApiVerbose | `Option[Boolean]` | The verbosity of generation |
 | openApiValidateSpec | `Option[Boolean]` | Whether or not an input specification should be validated upon generation |
 | openApiTemplateDir | `String` | The template directory holding a custom template |

--- a/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorKeys.scala
+++ b/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorKeys.scala
@@ -31,7 +31,8 @@ trait OpenApiGeneratorKeys {
     "Supported options can be different for each language. Run config-help -g {generator name} command for language specific config options.")
   final val openApiAdditionalProperties = settingKey[Map[String, String]]("Sets additional properties that can be referenced by the mustache templates in the format of name=value,name=value.\n" +
     "You can also have multiple occurrences of this option.")
-  final val openApiSystemProperties = settingKey[Map[String, String]]("Sets specified system properties.")
+  @deprecated("use openApiGlobalProperties instead") final val openApiSystemProperties = settingKey[Map[String, String]]("Sets specified system properties.")
+  final val openApiGlobalProperties = settingKey[Map[String, String]]("Sets specified system properties.")
 
   final val openApiVerbose = settingKey[Option[Boolean]]("The verbosity of generation")
   final val openApiValidateSpec = settingKey[Option[Boolean]]("Whether or not an input specification should be validated upon generation.")

--- a/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorPlugin.scala
+++ b/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorPlugin.scala
@@ -54,6 +54,7 @@ object OpenApiGeneratorPlugin extends sbt.AutoPlugin
     openApiConfigFile := "",
     openApiAdditionalProperties := Map.empty[String, String],
     openApiSystemProperties := Map.empty[String, String],
+    openApiGlobalProperties := Map.empty[String, String],
     openApiVerbose := None,
     openApiValidateSpec := None,
     openApiGeneratorName := "",

--- a/src/main/scala/org/openapitools/generator/sbt/plugin/tasks/OpenApiGenerateTask.scala
+++ b/src/main/scala/org/openapitools/generator/sbt/plugin/tasks/OpenApiGenerateTask.scala
@@ -196,9 +196,9 @@ trait OpenApiGenerateTask extends OpenApiGeneratorKeys {
         configurator.setGenerateAliasAsModel(value)
       }
 
-      if (openApiSystemProperties.value.nonEmpty) {
-        openApiSystemProperties.value.foreach { entry =>
-          configurator.addSystemProperty(entry._1, entry._2)
+      if (openApiGlobalProperties.value.nonEmpty || openApiSystemProperties.value.nonEmpty) {
+        (openApiSystemProperties.value ++ openApiGlobalProperties.value).foreach { entry =>
+          configurator.addGlobalProperty(entry._1, entry._2)
         }
       }
 
@@ -258,7 +258,7 @@ trait OpenApiGenerateTask extends OpenApiGeneratorKeys {
               throw new Exception("Code generation failed.", ex)
           }
         case Failure(ex) =>
-          logger.info(ex.getMessage)
+          logger.err(ex.getMessage)
           Seq.empty
       }
     }


### PR DESCRIPTION
openapi renamed "system properties" to "global properties". I updated sbt plugin, and deprecated old setting. I also changed logging on exception from info to error.