### PR TITLE
5.0.0-beta2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val openApiGeneratorVersion = "5.0.0-SNAPSHOT"
+val openApiGeneratorVersion = "5.0.0-beta2"
 
 ThisBuild / name := "sbt-openapi-generator"
 ThisBuild / description :=

--- a/src/main/scala/org/openapitools/generator/sbt/plugin/tasks/OpenApiGenerateTask.scala
+++ b/src/main/scala/org/openapitools/generator/sbt/plugin/tasks/OpenApiGenerateTask.scala
@@ -198,7 +198,7 @@ trait OpenApiGenerateTask extends OpenApiGeneratorKeys {
 
       if (openApiSystemProperties.value.nonEmpty) {
         openApiSystemProperties.value.foreach { entry =>
-          configurator.addSystemProperty(entry._1, entry._2)
+          configurator.addGlobalProperty(entry._1, entry._2)
         }
       }
 


### PR DESCRIPTION
1. Lifted OpenApiGenerator to version 5.0.0-beta2.
2. Renamed addSystemProperty to addGlobalProperty inside OpenApiGenerate.scala.