### PR TITLE
Add a hook for generating metadata files

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,11 @@ sbt generated/openApiGenerate
 | openApiEnablePostProcessFile | `Option[Boolean]` | Enable post-processing file using environment variables | \
 | openApiSkipValidateSpec | `Option[Boolean]` | To skip spec validation. When true, we will skip the default behavior of validating a spec before generation |
 | openApiGenerateAliasAsModel | `Option[Boolean]` | Generate model implementation for aliases to map and array schemas |
+| openApiGenerateMetadata | `Option[Boolean]` | Generate metadata files used by OpenAPI Generator. This includes `.openapi-generator-ignore` and any files within `.openapi-generator`. |
 
 # Examples
 
-Please see [an sbt-test configuration](src/sbt-test) for using the plugin. 
+Please see [an sbt-test configuration](src/sbt-test) for examples of using the plugin.
 Do not run those examples directly, please copy them to separate place first.
 
 # Contribution and Tests

--- a/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorKeys.scala
+++ b/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorKeys.scala
@@ -161,4 +161,11 @@ trait OpenApiGeneratorKeys {
    */
   final val openApiGenerateAliasAsModel = settingKey[Option[Boolean]](CodegenConstants.GENERATE_ALIAS_AS_MODEL_DESC)
 
+  /**
+   * Indicate whether or not to generate OpenAPI Generator metadata files.
+   * These files include .openapi-generator/VERSION, .openapi-generator-ignore, and any other metadata files
+   * used by OpenAPI Generator.
+   */
+  final val openApiGenerateMetadata = settingKey[Option[Boolean]]("Generate metadata files used by OpenAPI Generator. This includes .openapi-generator-ignore and any files within .openapi-generator.")
+
 }

--- a/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorPlugin.scala
+++ b/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorPlugin.scala
@@ -94,7 +94,8 @@ object OpenApiGeneratorPlugin extends sbt.AutoPlugin
     openApiLogToStderr := None,
     openApiEnablePostProcessFile := None,
     openApiSkipValidateSpec := None,
-    openApiGenerateAliasAsModel := None
+    openApiGenerateAliasAsModel := None,
+    openApiGenerateMetadata := None
   )
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = Seq[sbt.Setting[_]](

--- a/src/main/scala/org/openapitools/generator/sbt/plugin/tasks/OpenApiGenerateTask.scala
+++ b/src/main/scala/org/openapitools/generator/sbt/plugin/tasks/OpenApiGenerateTask.scala
@@ -247,7 +247,14 @@ trait OpenApiGenerateTask extends OpenApiGeneratorKeys {
       Try(configurator.toClientOptInput) match {
         case Success(clientOptInput) =>
           Try {
-            val gen = new DefaultGenerator().opts(clientOptInput)
+            val gen = new DefaultGenerator()
+
+            gen.opts(clientOptInput)
+
+            openApiGenerateMetadata.value.foreach { value =>
+              gen.setGenerateMetadata(value)
+            }
+
             val res = gen.generate().asScala
 
             logger.info(s"Successfully generated code to ${clientOptInput.getConfig.getOutputDir}")


### PR DESCRIPTION
Move the metadata generation hook into the sbt plugin.

Adds the setting key `openApiGenerateMetadata` which is explicitly checked in the `openApiGenerate` task.

@jimschubert 