### PR TITLE
Switch to sbt-dynver for versioning.

### DIFF
--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -13,12 +13,17 @@ on:
   pull_request:
     branches:
       - 'master'
+  release:
+    types:
+      - 'published'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
@@ -34,9 +39,9 @@ jobs:
           path: ~/.sbt
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/*.sbt') }}
       - name: Run tests
-        run: sbt '^test; ^scripted;'
+        run: sbt ^test ^scripted
       - name: Publish
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')
         env:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_PASS: ${{ secrets.BINTRAY_PASS }}

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-val openApiGeneratorVersion = "5.0.0-beta2"
-
 ThisBuild / name := "sbt-openapi-generator"
 ThisBuild / description :=
   """
@@ -15,23 +13,13 @@ lazy val `sbt-openapi-generator` = (project in file("."))
     crossScalaVersions := Seq(scalaVersion.value, "2.11.12"),
     crossSbtVersions := List("0.13.17", "1.3.10"),
     sbtPlugin := true,
+
     publishMavenStyle := false,
+
     bintrayRepository := "sbt-plugins",
     bintrayOrganization := Option("openapitools"),
     bintrayPackageLabels := Seq("sbt", "plugin", "oas", "openapi", "openapi-generator"),
     bintrayVcsUrl := Some("git@github.com:OpenAPITools/sbt-openapi-generator.git"),
-    git.baseVersion := openApiGeneratorVersion.replace("-SNAPSHOT", ""),
-    git.formattedShaVersion := {
-      if(isSnapshot.value) {
-        git.gitHeadCommit.value map { sha =>
-          git.defaultFormatShaVersion(
-            Some(git.formattedDateVersion.value),
-            sha.slice(0, 8),
-            ""
-          )
-        }
-      } else Option(openApiGeneratorVersion)
-    },
 
     scriptedLaunchOpts := {
       scriptedLaunchOpts.value ++ Seq("-Xmx1024M", "-server", "-Dplugin.version=" + version.value)
@@ -66,7 +54,5 @@ lazy val `sbt-openapi-generator` = (project in file("."))
         devConnection = "scm:git:ssh://git@github.com:OpenAPITools/openapi-generator.git")
     ),
 
-    isSnapshot := openApiGeneratorVersion.endsWith("-SNAPSHOT"),
-
-    libraryDependencies += "org.openapitools" % "openapi-generator" % openApiGeneratorVersion
-  ).enablePlugins(GitVersioning, SbtPlugin)
+    libraryDependencies += "org.openapitools" % "openapi-generator" % "5.0.0-beta2"
+  ).enablePlugins(SbtPlugin)

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -1,3 +1,5 @@
+// Manages publishing.
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.6")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+// Versions the build.
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")


### PR DESCRIPTION
Switch to using [`sbt-dynver`](https://github.com/dwijnand/sbt-dynver) for versioning.

Merged pull requests will publish snapshots automatically - for example, if you tag `master` at `v5.0.0-beta2` before merging this, the next published version after merging would be something like `5.0.0-beta2+1-f7c1a0cb`.

I also added a `release` trigger for the `sbt` github action, which will publish versioned artifacts whenever you create a new tag on `master`. So, the workflow for releasing new versions would simply be updating the dependency version, merging, and creating a github release.

I tested this out on my fork and it seems to work.
* [action execution](https://github.com/jrouly/sbt-openapi-generator/actions/runs/387671990) after merging in [a dependency bump to `5.0.0-beta3`](https://github.com/jrouly/sbt-openapi-generator/commit/44a9672417d12d647f70324cf992fca02241824c) published to Bintray as [`5.0.0-beta2+8-44a96724`](https://bintray.com/jrouly/sbt-plugins/sbt-openapi-generator/5.0.0-beta2%2B8-44a96724).
* [action execution](https://github.com/jrouly/sbt-openapi-generator/actions/runs/387672482) after publishing [a new release `v5.0.0-beta3`](https://github.com/jrouly/sbt-openapi-generator/tree/v5.0.0-beta3) published to Bintray as [`5.0.0-beta3`](https://bintray.com/jrouly/sbt-plugins/sbt-openapi-generator/5.0.0-beta3).

Per the dynver docs, you can [replace the `+` with a `-` in snapshot version strings](https://github.com/dwijnand/sbt-dynver#portable-version-strings) or [force `-SNAPSHOT` for Sonatype compatibility](https://github.com/dwijnand/sbt-dynver#publishing-to-sonatypes-snapshots-repository-aka-sonatype-mode), if either of those are interesting to you. Not sure what your plans for this repo are. Alternatively you can [totally customize the version strings](https://github.com/dwijnand/sbt-dynver#custom-version-string).

@jimschubert 