### PR TITLE
Update OpenAPI Generator to 5.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val openApiGeneratorVersion = "5.0.0-beta2"
+val openApiGeneratorVersion = "5.0.0"
 
 ThisBuild / name := "sbt-openapi-generator"
 ThisBuild / description :=


### PR DESCRIPTION
I guess there are no breaking changes, so the version can be simply bumped