### PR TITLE
Update/openapi generator 5.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-val openApiGeneratorVersion = "5.0.0-beta2"
+val openApiGeneratorVersion = "5.0.0"
 
 ThisBuild / name := "sbt-openapi-generator"
 ThisBuild / description :=


### PR DESCRIPTION
Sweetness! Now that `dynver` is in place, we should be able to merge this PR.

Merging will trigger `5.0.0-beta2+2-<sha>` to be built. @jimschubert can then create a release/tag `v5.0.0` and it should get published automatically. :crossed_fingers: 