### PR TITLE
downgrade version in README for the latest published version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Sbt plugin to support the OpenAPI generator project.
 Add to your `project/plugins.sbt`:
 
 ```sbt
-addSbtPlugin("org.openapitools" % "sbt-openapi-generator" % "5.3.0")
+addSbtPlugin("org.openapitools" % "sbt-openapi-generator" % "5.0.1")
 ```
 
 # Configuration


### PR DESCRIPTION
version `5.3.0` is not published to the sbt plugins repo.
Checking the repo:
https://scala.jfrog.io/ui/native/sbt-plugin-releases/org.openapitools/sbt-openapi-generator/scala_2.12/sbt_1.0/
it seems that version `5.0.1` is the latest published version.

Changing the README helps newcomers to avoid such build errors:
```
[error]   not found: https://repo.scala-sbt.org/scalasbt/sbt-plugin-releases/org.openapitools/sbt-openapi-generator/scala_2.12/sbt_1.0/5.3.0/ivys/ivy.xml
[error]   not found: https://repo.typesafe.com/typesafe/ivy-releases/org.openapitools/sbt-openapi-generator/scala_2.12/sbt_1.0/5.3.0/ivys/ivy.xml
[error]   not found: https://repo.typesafe.com/typesafe/releases/org/openapitools/sbt-openapi-generator_2.12_1.0/5.3.0/sbt-openapi-generator-5.3.0.pom
[error]         at lmcoursier.CoursierDependencyResolution.unresolvedWarningOrThrow(CoursierDependencyResolution.scala:258)
[error]         at lmcoursier.CoursierDependencyResolution.$anonfun$update$38(CoursierDependencyResolution.scala:227)
…
[error]         at java.lang.Thread.run(Thread.java:750)
[error] (update) sbt.librarymanagement.ResolveException: Error downloading org.openapitools:sbt-openapi-generator;sbtVersion=1.0;scalaVersion=2.12:5.3.0
```

Also, please publish newer versions 🙏