### PR TITLE
bump openapi-generator and sbt version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,5 +54,5 @@ lazy val `sbt-openapi-generator` = (project in file("."))
         devConnection = "scm:git:ssh://git@github.com:OpenAPITools/openapi-generator.git")
     ),
 
-    libraryDependencies += "org.openapitools" % "openapi-generator" % "5.3.0"
+    libraryDependencies += "org.openapitools" % "openapi-generator" % "6.1.0"
   ).enablePlugins(SbtPlugin)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.6.2


### PR DESCRIPTION
This PR aims to update `openapi-generator` to a more recent version, reason being: when compiling the generated code, this error appears

```
[error] [E1] openapi/src/main/scala/org/openapitools/client/core/JsonSupport.scala
[error]      object client is not a member of package sttp
[error]      did you mean client3?
[error]      L16: import sttp.client.json4s.SttpJson4sApi
```

this is due to the fact that [the artifact was moved](https://mvnrepository.com/artifact/com.softwaremill.sttp.client/core):
```
Note: This artifact was moved to:

com.softwaremill.sttp.client3 » core
```

I also bumped sbt version in order to be able to run it on macos, but that's not a hard requirement.