### PR TITLE
Upgrade openapi generator dependency to v6.6.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -54,5 +54,5 @@ lazy val `sbt-openapi-generator` = (project in file("."))
         devConnection = "scm:git:ssh://git@github.com:OpenAPITools/openapi-generator.git")
     ),
 
-    libraryDependencies += "org.openapitools" % "openapi-generator" % "6.2.0"
+    libraryDependencies += "org.openapitools" % "openapi-generator" % "6.6.0"
   ).enablePlugins(SbtPlugin)


### PR DESCRIPTION
This PR aims to update openapi-generator to a more recent version in order to enable support for the apache-http library (which is not supported in the current version).
This plugin: 
<img width="355" alt="image" src="https://github.com/OpenAPITools/sbt-openapi-generator/assets/38635516/b7527d89-206b-4da9-af1e-a7d5cd03adce">

Gradle/Maven plugin:
<img width="226" alt="image" src="https://github.com/OpenAPITools/sbt-openapi-generator/assets/38635516/726a12fd-e008-40b6-b1ba-fe50611dc522">
