### PR TITLE
Build against Java 8

### DIFF
--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 8
           distribution: temurin
       - name: Cache SBT ivy cache
         uses: actions/cache@v1


### PR DESCRIPTION
We want to use this plugin on a project that still supports Java 8.

Java 8 still gets extended support until December 2030.
https://www.oracle.com/java/technologies/java-se-support-roadmap.html
