### PR TITLE
Expose task to return OpenAPI generator inputs

### DIFF
--- a/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorKeys.scala
+++ b/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorKeys.scala
@@ -17,11 +17,12 @@
 
 package org.openapitools.generator.sbt.plugin
 
-import org.openapitools.codegen.CodegenConstants
+import org.openapitools.codegen.{ClientOptInput, CodegenConstants}
 import sbt.{File, settingKey, taskKey}
 
 trait OpenApiGeneratorKeys {
   final val openApiGenerate = taskKey[Seq[File]]("Generate code via Open API Tools Generator for Open API 2.0 or 3.x specification documents.")
+  final val openApiGenerateInputs = taskKey[Option[ClientOptInput]]("Generates the user-provided config in a format that can be fed to a org.openapitools.codegen.Generator")
   final val openApiGenerators = taskKey[Unit]("Print list of available generators")
 
   final val openApiInputSpec = settingKey[String]("The Open API 2.0/3.x specification location.")

--- a/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorPlugin.scala
+++ b/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorPlugin.scala
@@ -17,14 +17,15 @@
 
 package org.openapitools.generator.sbt.plugin
 
-import org.openapitools.generator.sbt.plugin.tasks.{OpenApiGenerateTask, OpenApiGeneratorsTask}
+import org.openapitools.generator.sbt.plugin.tasks.{OpenApiGenerateInputsTask, OpenApiGenerateTask, OpenApiGeneratorsTask}
 import sbt.Keys.aggregate
 import sbt.plugins.JvmPlugin
 import sbt.{Def, File, config, taskKey}
 
 object OpenApiGeneratorPlugin extends sbt.AutoPlugin
   with OpenApiGeneratorsTask
-  with OpenApiGenerateTask {
+  with OpenApiGenerateTask
+  with OpenApiGenerateInputsTask {
   self =>
 
   override def requires: JvmPlugin.type = sbt.plugins.JvmPlugin
@@ -100,7 +101,8 @@ object OpenApiGeneratorPlugin extends sbt.AutoPlugin
 
   override lazy val projectSettings: Seq[Def.Setting[_]] = Seq[sbt.Setting[_]](
     openApiGenerators := openApiGeneratorsTask.value,
-    openApiGenerate := openApiGenerateTask.value
+    openApiGenerate := openApiGenerateTask.value,
+    openApiGenerateInputs := openApiGenerateInputsTask.value
   ) ++ baseSettings
 
 }

--- a/src/main/scala/org/openapitools/generator/sbt/plugin/tasks/OpenApiGenerateInputsTask.scala
+++ b/src/main/scala/org/openapitools/generator/sbt/plugin/tasks/OpenApiGenerateInputsTask.scala
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2020 OpenAPI-Generator Contributors (https://openapi-generator.tech)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openapitools.generator.sbt.plugin.tasks
+
+import org.openapitools.codegen.config.{CodegenConfigurator, GlobalSettings}
+import org.openapitools.codegen.{ClientOptInput, CodegenConstants, DefaultGenerator}
+import org.openapitools.generator.sbt.plugin.OpenApiGeneratorKeys
+import sbt.Keys._
+import sbt.{Def, _}
+
+import scala.util.{Failure, Success, Try}
+
+trait OpenApiGenerateInputsTask extends OpenApiGeneratorKeys {
+
+  protected[this] def openApiGenerateInputsTask: Def.Initialize[Task[Option[ClientOptInput]]] = Def.task {
+
+    val logger = sbt.Keys.streams.value.log
+
+    if (openApiConfigFile.value.isEmpty && openApiGeneratorName.value.isEmpty) {
+      None
+    } else {
+      val configurator: CodegenConfigurator = if (openApiConfigFile.value.nonEmpty) {
+        val config = openApiConfigFile.value
+        logger.info(s"read configuration from $config")
+        CodegenConfigurator.fromFile(config)
+      } else new CodegenConfigurator()
+
+      if (openApiSupportingFilesConstrainedTo.value.nonEmpty) {
+        GlobalSettings.setProperty(CodegenConstants.SUPPORTING_FILES, openApiSupportingFilesConstrainedTo.value.mkString(","))
+      } else {
+        GlobalSettings.clearProperty(CodegenConstants.SUPPORTING_FILES)
+      }
+
+      if (openApiModelFilesConstrainedTo.value.nonEmpty) {
+        GlobalSettings.setProperty(CodegenConstants.MODELS, openApiModelFilesConstrainedTo.value.mkString(","))
+      } else {
+        GlobalSettings.clearProperty(CodegenConstants.MODELS)
+      }
+
+      if (openApiApiFilesConstrainedTo.value.nonEmpty) {
+        GlobalSettings.setProperty(CodegenConstants.APIS, openApiApiFilesConstrainedTo.value.mkString(","))
+      } else {
+        GlobalSettings.clearProperty(CodegenConstants.APIS)
+      }
+
+      openApiGenerateApiDocumentation.value.foreach { value =>
+        GlobalSettings.setProperty(CodegenConstants.API_DOCS, value.toString)
+      }
+
+      openApiGenerateModelDocumentation.value.foreach { value =>
+        GlobalSettings.setProperty(CodegenConstants.MODEL_DOCS, value.toString)
+      }
+
+      openApiGenerateModelTests.value.foreach { value =>
+        GlobalSettings.setProperty(CodegenConstants.MODEL_TESTS, value.toString)
+      }
+
+      openApiGenerateApiTests.value.foreach { value =>
+        GlobalSettings.setProperty(CodegenConstants.API_TESTS, value.toString)
+      }
+
+      openApiWithXml.value.foreach { value =>
+        GlobalSettings.setProperty(CodegenConstants.WITH_XML, value.toString)
+      }
+
+      // now override with any specified parameters
+      openApiVerbose.value.foreach { value =>
+        configurator.setVerbose(value)
+      }
+      openApiValidateSpec.value.foreach { value =>
+        configurator.setValidateSpec(value)
+      }
+
+      openApiSkipOverwrite.value.foreach { value =>
+        configurator.setSkipOverwrite(value)
+      }
+
+      if (openApiInputSpec.value.nonEmpty) {
+        configurator.setInputSpec(openApiInputSpec.value)
+      }
+
+
+      if (openApiGeneratorName.value.nonEmpty) {
+        configurator.setGeneratorName(openApiGeneratorName.value)
+      }
+
+      if (openApiOutputDir.value.nonEmpty) {
+        configurator.setOutputDir(openApiOutputDir.value)
+      }
+
+      if (openApiAuth.value.nonEmpty) {
+        configurator.setAuth(openApiAuth.value)
+      }
+
+      if (openApiTemplateDir.value.nonEmpty) {
+        configurator.setTemplateDir(openApiTemplateDir.value)
+      }
+
+      if (openApiPackageName.value.nonEmpty) {
+        configurator.setPackageName(openApiPackageName.value)
+      }
+
+      if (openApiApiPackage.value.nonEmpty) {
+        configurator.setApiPackage(openApiApiPackage.value)
+      }
+
+      if (openApiModelPackage.value.nonEmpty) {
+        configurator.setModelPackage(openApiModelPackage.value)
+      }
+
+      if (openApiModelNamePrefix.value.nonEmpty) {
+        configurator.setModelNamePrefix(openApiModelNamePrefix.value)
+      }
+
+      if (openApiModelNameSuffix.value.nonEmpty) {
+        configurator.setModelNameSuffix(openApiModelNameSuffix.value)
+      }
+
+      if (openApiInvokerPackage.value.nonEmpty) {
+        configurator.setInvokerPackage(openApiInvokerPackage.value)
+      }
+
+      if (openApiGroupId.value.nonEmpty) {
+        configurator.setGroupId(openApiGroupId.value)
+      }
+
+      if (openApiId.value.nonEmpty) {
+        configurator.setArtifactId(openApiId.value)
+      }
+
+      if ((version in openApiGenerate).value.nonEmpty) {
+        configurator.setArtifactVersion(version.value)
+      }
+
+      if (openApiLibrary.value.nonEmpty) {
+        configurator.setLibrary(openApiLibrary.value)
+      }
+
+      if (openApiGitHost.value.nonEmpty) {
+        configurator.setGitHost(openApiGitHost.value)
+      }
+
+      if (openApiGitUserId.value.nonEmpty) {
+        configurator.setGitUserId(openApiGitUserId.value)
+      }
+
+
+      if (openApiGitRepoId.value.nonEmpty) {
+        configurator.setGitRepoId(openApiGitRepoId.value)
+      }
+
+      if (openApiReleaseNote.value.nonEmpty) {
+        configurator.setReleaseNote(openApiReleaseNote.value)
+      }
+
+      if (openApiHttpUserAgent.value.nonEmpty) {
+        configurator.setHttpUserAgent(openApiHttpUserAgent.value)
+      }
+
+      if (openApiIgnoreFileOverride.value.nonEmpty) {
+        configurator.setIgnoreFileOverride(openApiIgnoreFileOverride.value)
+      }
+
+      openApiRemoveOperationIdPrefix.value.foreach { value =>
+        configurator.setRemoveOperationIdPrefix(value)
+      }
+
+      openApiLogToStderr.value.foreach { value =>
+        configurator.setLogToStderr(value)
+      }
+
+      openApiEnablePostProcessFile.value.foreach { value =>
+        configurator.setEnablePostProcessFile(value)
+      }
+
+      openApiSkipValidateSpec.value.foreach { value =>
+        configurator.setValidateSpec(!value)
+      }
+
+      openApiGenerateAliasAsModel.value.foreach { value =>
+        configurator.setGenerateAliasAsModel(value)
+      }
+
+      if (openApiGlobalProperties.value.nonEmpty || openApiSystemProperties.value.nonEmpty) {
+        (openApiSystemProperties.value ++ openApiGlobalProperties.value).foreach { entry =>
+          configurator.addGlobalProperty(entry._1, entry._2)
+        }
+      }
+
+      if (openApiInstantiationTypes.value.nonEmpty) {
+        openApiInstantiationTypes.value.foreach { entry =>
+          configurator.addInstantiationType(entry._1, entry._2)
+        }
+      }
+
+      if (openApiImportMappings.value.nonEmpty) {
+        openApiImportMappings.value.foreach { entry =>
+          configurator.addImportMapping(entry._1, entry._2)
+        }
+      }
+
+      if (openApiTypeMappings.value.nonEmpty) {
+        openApiTypeMappings.value.foreach { entry =>
+          configurator.addTypeMapping(entry._1, entry._2)
+        }
+      }
+
+      if (openApiAdditionalProperties.value.nonEmpty) {
+        openApiAdditionalProperties.value.foreach { entry =>
+          configurator.addAdditionalProperty(entry._1, entry._2)
+        }
+      }
+
+      if (openApiServerVariables.value.nonEmpty) {
+        openApiServerVariables.value.foreach { entry =>
+          configurator.addServerVariable(entry._1, entry._2)
+        }
+      }
+
+      if (openApiLanguageSpecificPrimitives.value.nonEmpty) {
+        openApiLanguageSpecificPrimitives.value.foreach { it =>
+          configurator.addLanguageSpecificPrimitive(it)
+        }
+      }
+
+      if (openApiReservedWordsMappings.value.nonEmpty) {
+        openApiReservedWordsMappings.value.foreach { entry =>
+          configurator.addAdditionalReservedWordMapping(entry._1, entry._2)
+        }
+      }
+
+      Try(configurator.toClientOptInput) match {
+        case Success(clientOptInput) =>
+          Some(clientOptInput)
+
+        case Failure(ex) =>
+          logger.error(ex.getMessage)
+          None
+      }
+    }
+  }
+}

--- a/src/main/scala/org/openapitools/generator/sbt/plugin/tasks/OpenApiGenerateTask.scala
+++ b/src/main/scala/org/openapitools/generator/sbt/plugin/tasks/OpenApiGenerateTask.scala
@@ -16,10 +16,8 @@
  */
 package org.openapitools.generator.sbt.plugin.tasks
 
-import org.openapitools.codegen.config.{CodegenConfigurator, GlobalSettings}
-import org.openapitools.codegen.{CodegenConstants, DefaultGenerator}
+import org.openapitools.codegen.DefaultGenerator
 import org.openapitools.generator.sbt.plugin.OpenApiGeneratorKeys
-import sbt.Keys._
 import sbt.{Def, _}
 
 import scala.collection.JavaConverters._
@@ -31,243 +29,29 @@ trait OpenApiGenerateTask extends OpenApiGeneratorKeys {
 
     val logger = sbt.Keys.streams.value.log
 
-    if (openApiConfigFile.value.isEmpty && openApiGeneratorName.value.isEmpty) {
-      Seq()
-    } else {
-      val configurator: CodegenConfigurator = if (openApiConfigFile.value.nonEmpty) {
-        val config = openApiConfigFile.value
-        logger.info(s"read configuration from $config")
-        CodegenConfigurator.fromFile(config)
-      } else new CodegenConfigurator()
+    openApiGenerateInputs.value match {
+      case Some(clientOptInput) =>
+        Try {
+          val gen = new DefaultGenerator()
 
-      if (openApiSupportingFilesConstrainedTo.value.nonEmpty) {
-        GlobalSettings.setProperty(CodegenConstants.SUPPORTING_FILES, openApiSupportingFilesConstrainedTo.value.mkString(","))
-      } else {
-        GlobalSettings.clearProperty(CodegenConstants.SUPPORTING_FILES)
-      }
+          gen.opts(clientOptInput)
 
-      if (openApiModelFilesConstrainedTo.value.nonEmpty) {
-        GlobalSettings.setProperty(CodegenConstants.MODELS, openApiModelFilesConstrainedTo.value.mkString(","))
-      } else {
-        GlobalSettings.clearProperty(CodegenConstants.MODELS)
-      }
-
-      if (openApiApiFilesConstrainedTo.value.nonEmpty) {
-        GlobalSettings.setProperty(CodegenConstants.APIS, openApiApiFilesConstrainedTo.value.mkString(","))
-      } else {
-        GlobalSettings.clearProperty(CodegenConstants.APIS)
-      }
-
-      openApiGenerateApiDocumentation.value.foreach { value =>
-        GlobalSettings.setProperty(CodegenConstants.API_DOCS, value.toString)
-      }
-
-      openApiGenerateModelDocumentation.value.foreach { value =>
-        GlobalSettings.setProperty(CodegenConstants.MODEL_DOCS, value.toString)
-      }
-
-      openApiGenerateModelTests.value.foreach { value =>
-        GlobalSettings.setProperty(CodegenConstants.MODEL_TESTS, value.toString)
-      }
-
-      openApiGenerateApiTests.value.foreach { value =>
-        GlobalSettings.setProperty(CodegenConstants.API_TESTS, value.toString)
-      }
-
-      openApiWithXml.value.foreach { value =>
-        GlobalSettings.setProperty(CodegenConstants.WITH_XML, value.toString)
-      }
-
-      // now override with any specified parameters
-      openApiVerbose.value.foreach { value =>
-        configurator.setVerbose(value)
-      }
-      openApiValidateSpec.value.foreach { value =>
-        configurator.setValidateSpec(value)
-      }
-
-      openApiSkipOverwrite.value.foreach { value =>
-        configurator.setSkipOverwrite(value)
-      }
-
-      if (openApiInputSpec.value.nonEmpty) {
-        configurator.setInputSpec(openApiInputSpec.value)
-      }
-
-
-      if (openApiGeneratorName.value.nonEmpty) {
-        configurator.setGeneratorName(openApiGeneratorName.value)
-      }
-
-      if (openApiOutputDir.value.nonEmpty) {
-        configurator.setOutputDir(openApiOutputDir.value)
-      }
-
-      if (openApiAuth.value.nonEmpty) {
-        configurator.setAuth(openApiAuth.value)
-      }
-
-      if (openApiTemplateDir.value.nonEmpty) {
-        configurator.setTemplateDir(openApiTemplateDir.value)
-      }
-
-      if (openApiPackageName.value.nonEmpty) {
-        configurator.setPackageName(openApiPackageName.value)
-      }
-
-      if (openApiApiPackage.value.nonEmpty) {
-        configurator.setApiPackage(openApiApiPackage.value)
-      }
-
-      if (openApiModelPackage.value.nonEmpty) {
-        configurator.setModelPackage(openApiModelPackage.value)
-      }
-
-      if (openApiModelNamePrefix.value.nonEmpty) {
-        configurator.setModelNamePrefix(openApiModelNamePrefix.value)
-      }
-
-      if (openApiModelNameSuffix.value.nonEmpty) {
-        configurator.setModelNameSuffix(openApiModelNameSuffix.value)
-      }
-
-      if (openApiInvokerPackage.value.nonEmpty) {
-        configurator.setInvokerPackage(openApiInvokerPackage.value)
-      }
-
-      if (openApiGroupId.value.nonEmpty) {
-        configurator.setGroupId(openApiGroupId.value)
-      }
-
-      if (openApiId.value.nonEmpty) {
-        configurator.setArtifactId(openApiId.value)
-      }
-
-      if ((version in openApiGenerate).value.nonEmpty) {
-        configurator.setArtifactVersion(version.value)
-      }
-
-      if (openApiLibrary.value.nonEmpty) {
-        configurator.setLibrary(openApiLibrary.value)
-      }
-
-      if (openApiGitHost.value.nonEmpty) {
-        configurator.setGitHost(openApiGitHost.value)
-      }
-
-      if (openApiGitUserId.value.nonEmpty) {
-        configurator.setGitUserId(openApiGitUserId.value)
-      }
-
-
-      if (openApiGitRepoId.value.nonEmpty) {
-        configurator.setGitRepoId(openApiGitRepoId.value)
-      }
-
-      if (openApiReleaseNote.value.nonEmpty) {
-        configurator.setReleaseNote(openApiReleaseNote.value)
-      }
-
-      if (openApiHttpUserAgent.value.nonEmpty) {
-        configurator.setHttpUserAgent(openApiHttpUserAgent.value)
-      }
-
-      if (openApiIgnoreFileOverride.value.nonEmpty) {
-        configurator.setIgnoreFileOverride(openApiIgnoreFileOverride.value)
-      }
-
-      openApiRemoveOperationIdPrefix.value.foreach { value =>
-        configurator.setRemoveOperationIdPrefix(value)
-      }
-
-      openApiLogToStderr.value.foreach { value =>
-        configurator.setLogToStderr(value)
-      }
-
-      openApiEnablePostProcessFile.value.foreach { value =>
-        configurator.setEnablePostProcessFile(value)
-      }
-
-      openApiSkipValidateSpec.value.foreach { value =>
-        configurator.setValidateSpec(!value)
-      }
-
-      openApiGenerateAliasAsModel.value.foreach { value =>
-        configurator.setGenerateAliasAsModel(value)
-      }
-
-      if (openApiGlobalProperties.value.nonEmpty || openApiSystemProperties.value.nonEmpty) {
-        (openApiSystemProperties.value ++ openApiGlobalProperties.value).foreach { entry =>
-          configurator.addGlobalProperty(entry._1, entry._2)
-        }
-      }
-
-      if (openApiInstantiationTypes.value.nonEmpty) {
-        openApiInstantiationTypes.value.foreach { entry =>
-          configurator.addInstantiationType(entry._1, entry._2)
-        }
-      }
-
-      if (openApiImportMappings.value.nonEmpty) {
-        openApiImportMappings.value.foreach { entry =>
-          configurator.addImportMapping(entry._1, entry._2)
-        }
-      }
-
-      if (openApiTypeMappings.value.nonEmpty) {
-        openApiTypeMappings.value.foreach { entry =>
-          configurator.addTypeMapping(entry._1, entry._2)
-        }
-      }
-
-      if (openApiAdditionalProperties.value.nonEmpty) {
-        openApiAdditionalProperties.value.foreach { entry =>
-          configurator.addAdditionalProperty(entry._1, entry._2)
-        }
-      }
-
-      if (openApiServerVariables.value.nonEmpty) {
-        openApiServerVariables.value.foreach { entry =>
-          configurator.addServerVariable(entry._1, entry._2)
-        }
-      }
-
-      if (openApiLanguageSpecificPrimitives.value.nonEmpty) {
-        openApiLanguageSpecificPrimitives.value.foreach { it =>
-          configurator.addLanguageSpecificPrimitive(it)
-        }
-      }
-
-      if (openApiReservedWordsMappings.value.nonEmpty) {
-        openApiReservedWordsMappings.value.foreach { entry =>
-          configurator.addAdditionalReservedWordMapping(entry._1, entry._2)
-        }
-      }
-
-      Try(configurator.toClientOptInput) match {
-        case Success(clientOptInput) =>
-          Try {
-            val gen = new DefaultGenerator()
-
-            gen.opts(clientOptInput)
-
-            openApiGenerateMetadata.value.foreach { value =>
-              gen.setGenerateMetadata(value)
-            }
-
-            val res = gen.generate().asScala
-
-            logger.info(s"Successfully generated code to ${clientOptInput.getConfig.getOutputDir}")
-            res
-          } match {
-            case Success(value) => value
-            case Failure(ex) =>
-              throw new Exception("Code generation failed.", ex)
+          openApiGenerateMetadata.value.foreach { value =>
+            gen.setGenerateMetadata(value)
           }
-        case Failure(ex) =>
-          logger.error(ex.getMessage)
-          Seq.empty
-      }
+
+          val res = gen.generate().asScala
+
+          logger.info(s"Successfully generated code to ${clientOptInput.getConfig.getOutputDir}")
+          res
+        } match {
+          case Success(value) => value
+          case Failure(ex) =>
+            throw new Exception("Code generation failed.", ex)
+        }
+
+      case None =>
+        Seq.empty
     }
   }
 }


### PR DESCRIPTION
Extract the parsing of the SBT settings from `openApiGenerate` into a separate SBT task (`openApiGenerateInputs`) which returns a `org.openapitools.codegen.ClientOptInput`.

This new task is useful for building non-trivial code generation workflows, where e.g. we want to call the OpenAPI generator multiple times with small variations on the provided settings.