### PR TITLE
v7.21.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Sbt plugin to support the OpenAPI generator project.
 Add to your `project/plugins.sbt`:
 
 ```sbt
-addSbtPlugin("org.openapitools" % "sbt-openapi-generator" % "7.20.0")
+addSbtPlugin("org.openapitools" % "sbt-openapi-generator" % "7.21.0")
 ```
 
 # Configuration

--- a/build.sbt
+++ b/build.sbt
@@ -61,5 +61,5 @@ lazy val `sbt-openapi-generator` = (project in file("."))
     ),
 
 
-    libraryDependencies += "org.openapitools" % "openapi-generator" % "7.20.0",
+    libraryDependencies += "org.openapitools" % "openapi-generator" % "7.21.0",
   ).enablePlugins(SbtPlugin)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgrade `sbt-openapi-generator` and `openapi-generator` to 7.21.0, and update the README install snippet to match the v7.21.0 release.

<sup>Written for commit 50ef48d3f0fad53f16f6df0c60e15e3cd52223f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

