### PR TITLE
v7.22.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Sbt plugin to support the OpenAPI generator project.
 Add to your `project/plugins.sbt`:
 
 ```sbt
-addSbtPlugin("org.openapitools" % "sbt-openapi-generator" % "7.21.0")
+addSbtPlugin("org.openapitools" % "sbt-openapi-generator" % "7.22.0")
 ```
 
 # Configuration

--- a/build.sbt
+++ b/build.sbt
@@ -61,5 +61,5 @@ lazy val `sbt-openapi-generator` = (project in file("."))
     ),
 
 
-    libraryDependencies += "org.openapitools" % "openapi-generator" % "7.21.0",
+    libraryDependencies += "org.openapitools" % "openapi-generator" % "7.22.0",
   ).enablePlugins(SbtPlugin)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Release v7.22.0. Updates the README install snippet for `sbt-openapi-generator` and bumps the `org.openapitools:openapi-generator` dependency to 7.22.0.

<sup>Written for commit 68dd7714371cadd0fde17c46dc343f1a6f9f36fa. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/sbt-openapi-generator/pull/85?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

