### PR TITLE
update sbt 1.x to 1.12.10, make project compile against 2.0.0-RC12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ project/plugins/project/
 .vscode
 metals.sbt
 .bloop
+.scala-build/

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,10 @@ lazy val `sbt-openapi-generator` = (project in file("."))
         organizationName := "OpenAPI-Generator Contributors",
         organizationHomepage := Some(url("https://github.com/OpenAPITools")),
 
-        licenses += ("The Apache Software License, Version 2.0", url("https://www.apache.org/licenses/LICENSE-2.0.txt")),
+        licenses += (
+          "The Apache Software License, Version 2.0",
+          url("https://www.apache.org/licenses/LICENSE-2.0.txt")
+        ),
 
         developers += Developer(
           id = "openapitools",
@@ -36,7 +39,7 @@ lazy val `sbt-openapi-generator` = (project in file("."))
     ),
     moduleName := "sbt-openapi-generator",
     crossScalaVersions := Seq(scala21220),
-    //crossScalaVersions := Seq(scala21220, scala372),
+    // crossScalaVersions := Seq(scala21220, scala372),
     sbtPlugin := true,
     scalacOptions ++= {
       scalaBinaryVersion.value match {
@@ -46,20 +49,24 @@ lazy val `sbt-openapi-generator` = (project in file("."))
     },
     (pluginCrossBuild / sbtVersion) := {
       scalaBinaryVersion.value match {
-        case "2.12" => "1.5.8"
-        case _      => "2.0.0-RC3"
+        case "2.12" => "1.12.10"
+        case _      => "2.0.0-RC12"
       }
     },
     scriptedLaunchOpts := {
-      scriptedLaunchOpts.value ++ Seq("-Xmx1024M", "-server", "-Dplugin.version=" + version.value)
+      scriptedLaunchOpts.value ++ Seq(
+        "-Xmx1024M",
+        "-server",
+        "-Dplugin.version=" + version.value
+      )
     },
 
     scriptedBufferLog := false,
 
     resolvers ++= Seq(
-      Resolver.sbtPluginRepo("snapshots"),
+      Resolver.sbtPluginRepo("snapshots")
     ),
 
-
-    libraryDependencies += "org.openapitools" % "openapi-generator" % "7.22.0",
-  ).enablePlugins(SbtPlugin)
+    libraryDependencies += "org.openapitools" % "openapi-generator" % "7.22.0"
+  )
+  .enablePlugins(SbtPlugin)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.4
+sbt.version=1.12.10

--- a/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorKeys.scala
+++ b/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorKeys.scala
@@ -21,151 +21,232 @@ import org.openapitools.codegen.CodegenConstants
 import sbt.{File, settingKey, taskKey}
 
 trait OpenApiGeneratorKeys {
-  final val openApiGenerate = taskKey[Seq[File]]("Generate code via Open API Tools Generator for Open API 2.0 or 3.x specification documents.")
-  final val openApiGenerators = taskKey[Unit]("Print list of available generators")
+  @transient final val openApiGenerate = taskKey[Seq[File]](
+    "Generate code via Open API Tools Generator for Open API 2.0 or 3.x specification documents."
+  )
+  final val openApiGenerators =
+    taskKey[Unit]("Print list of available generators")
 
-  final val openApiInputSpec = settingKey[String]("The Open API 2.0/3.x specification location.")
-  final val openApiOutputDir = settingKey[String]("The output target directory into which code will be generated.")
-  final val openApiConfigFile = settingKey[String]("Path to json configuration file.\n" +
-    "File content should be in a json format { \"optionKey\":\"optionValue\", \"optionKey1\":\"optionValue1\"...}\n" +
-    "Supported options can be different for each language. Run config-help -g {generator name} command for language specific config options.")
-  final val openApiAdditionalProperties = settingKey[Map[String, String]]("Sets additional properties that can be referenced by the mustache templates in the format of name=value,name=value.\n" +
-    "You can also have multiple occurrences of this option.")
-  @deprecated("use openApiGlobalProperties instead") final val openApiSystemProperties = settingKey[Map[String, String]]("Sets specified system properties.")
-  final val openApiGlobalProperties = settingKey[Map[String, String]]("Sets specified system properties.")
+  final val openApiInputSpec =
+    settingKey[String]("The Open API 2.0/3.x specification location.")
+  final val openApiOutputDir = settingKey[String](
+    "The output target directory into which code will be generated."
+  )
+  final val openApiConfigFile = settingKey[String](
+    "Path to json configuration file.\n" +
+      "File content should be in a json format { \"optionKey\":\"optionValue\", \"optionKey1\":\"optionValue1\"...}\n" +
+      "Supported options can be different for each language. Run config-help -g {generator name} command for language specific config options."
+  )
+  final val openApiAdditionalProperties = settingKey[Map[String, String]](
+    "Sets additional properties that can be referenced by the mustache templates in the format of name=value,name=value.\n" +
+      "You can also have multiple occurrences of this option."
+  )
+  @deprecated(
+    "use openApiGlobalProperties instead"
+  ) final val openApiSystemProperties =
+    settingKey[Map[String, String]]("Sets specified system properties.")
+  final val openApiGlobalProperties =
+    settingKey[Map[String, String]]("Sets specified system properties.")
 
-  final val openApiVerbose = settingKey[Option[Boolean]]("The verbosity of generation")
-  final val openApiValidateSpec = settingKey[Option[Boolean]]("Whether or not an input specification should be validated upon generation.")
-  final val openApiGeneratorName = settingKey[String]("The name of the generator which will handle codegen. (see \"openApiGenerators\" task)")
-  final val openApiTemplateDir = settingKey[String]("The template directory holding a custom template.")
-  final val openApiAuth = settingKey[String]("Adds authorization headers when fetching the OpenAPI definitions remotely.\n" +
-    "Pass in a URL-encoded string of name:header with a comma separating multiple values")
-  final val openApiSkipOverwrite = settingKey[Option[Boolean]]("Specifies if the existing files should be overwritten during the generation.")
-  final val openApiPackageName = settingKey[String](CodegenConstants.PACKAGE_NAME_DESC)
-  final val openApiApiPackage = settingKey[String](CodegenConstants.API_PACKAGE_DESC)
-  final val openApiModelPackage = settingKey[String](CodegenConstants.MODEL_PACKAGE_DESC)
-  final val openApiModelNamePrefix = settingKey[String](CodegenConstants.MODEL_NAME_PREFIX_DESC)
-  final val openApiModelNameSuffix = settingKey[String](CodegenConstants.MODEL_NAME_SUFFIX_DESC)
-  final val openApiInstantiationTypes = settingKey[Map[String, String]]("Sets instantiation type mappings.")
-  final val openApiTypeMappings = settingKey[Map[String, String]]("Sets mappings between OpenAPI spec types and generated code types.")
-  final val openApiServerVariables = settingKey[Map[String, String]]("Sets server variable for server URL template substitution, in the format of name=value,name=value.\n"
-    + "You can also have multiple occurrences of this option.")
+  final val openApiVerbose =
+    settingKey[Option[Boolean]]("The verbosity of generation")
+  final val openApiValidateSpec = settingKey[Option[Boolean]](
+    "Whether or not an input specification should be validated upon generation."
+  )
+  final val openApiGeneratorName = settingKey[String](
+    "The name of the generator which will handle codegen. (see \"openApiGenerators\" task)"
+  )
+  final val openApiTemplateDir =
+    settingKey[String]("The template directory holding a custom template.")
+  final val openApiAuth = settingKey[String](
+    "Adds authorization headers when fetching the OpenAPI definitions remotely.\n" +
+      "Pass in a URL-encoded string of name:header with a comma separating multiple values"
+  )
+  final val openApiSkipOverwrite = settingKey[Option[Boolean]](
+    "Specifies if the existing files should be overwritten during the generation."
+  )
+  final val openApiPackageName =
+    settingKey[String](CodegenConstants.PACKAGE_NAME_DESC)
+  final val openApiApiPackage =
+    settingKey[String](CodegenConstants.API_PACKAGE_DESC)
+  final val openApiModelPackage =
+    settingKey[String](CodegenConstants.MODEL_PACKAGE_DESC)
+  final val openApiModelNamePrefix =
+    settingKey[String](CodegenConstants.MODEL_NAME_PREFIX_DESC)
+  final val openApiModelNameSuffix =
+    settingKey[String](CodegenConstants.MODEL_NAME_SUFFIX_DESC)
+  final val openApiInstantiationTypes =
+    settingKey[Map[String, String]]("Sets instantiation type mappings.")
+  final val openApiTypeMappings = settingKey[Map[String, String]](
+    "Sets mappings between OpenAPI spec types and generated code types."
+  )
+  final val openApiServerVariables = settingKey[Map[String, String]](
+    "Sets server variable for server URL template substitution, in the format of name=value,name=value.\n"
+      + "You can also have multiple occurrences of this option."
+  )
 
-  final val openApiLanguageSpecificPrimitives = settingKey[List[String]]("Specifies additional language specific primitive types in the format of type1,type2,type3,type3. For example: String,boolean,Boolean,Double.")
-  final val openApiImportMappings = settingKey[Map[String, String]]("Specifies mappings between a given class and the import that should be used for that class.")
-  final val openApiInvokerPackage = settingKey[String](CodegenConstants.INVOKER_PACKAGE_DESC)
-  //TODO: change to sbt organization
+  final val openApiLanguageSpecificPrimitives = settingKey[List[String]](
+    "Specifies additional language specific primitive types in the format of type1,type2,type3,type3. For example: String,boolean,Boolean,Double."
+  )
+  final val openApiImportMappings = settingKey[Map[String, String]](
+    "Specifies mappings between a given class and the import that should be used for that class."
+  )
+  final val openApiInvokerPackage =
+    settingKey[String](CodegenConstants.INVOKER_PACKAGE_DESC)
+  // TODO: change to sbt organization
   final val openApiGroupId = settingKey[String](CodegenConstants.GROUP_ID_DESC)
-  //TODO: change to sbt name
+  // TODO: change to sbt name
   final val openApiId = settingKey[String](CodegenConstants.ARTIFACT_ID_DESC)
 
   final val openApiLibrary = settingKey[String](CodegenConstants.LIBRARY_DESC)
   final val openApiGitHost = settingKey[String](CodegenConstants.GIT_HOST_DESC)
-  final val openApiGitUserId = settingKey[String](CodegenConstants.GIT_USER_ID_DESC)
-  final val openApiGitRepoId = settingKey[String](CodegenConstants.GIT_REPO_ID_DESC)
-  final val openApiReleaseNote = settingKey[String](CodegenConstants.RELEASE_NOTE_DESC)
-  final val openApiHttpUserAgent = settingKey[String](CodegenConstants.HTTP_USER_AGENT_DESC)
-  final val openApiReservedWordsMappings = settingKey[Map[String, String]]("Specifies how a reserved name should be escaped to.")
-  final val openApiIgnoreFileOverride = settingKey[String](CodegenConstants.IGNORE_FILE_OVERRIDE_DESC)
-  final val openApiRemoveOperationIdPrefix = settingKey[Option[Boolean]]("Remove prefix of operationId, e.g. config_getId => getId")
+  final val openApiGitUserId =
+    settingKey[String](CodegenConstants.GIT_USER_ID_DESC)
+  final val openApiGitRepoId =
+    settingKey[String](CodegenConstants.GIT_REPO_ID_DESC)
+  final val openApiReleaseNote =
+    settingKey[String](CodegenConstants.RELEASE_NOTE_DESC)
+  final val openApiHttpUserAgent =
+    settingKey[String](CodegenConstants.HTTP_USER_AGENT_DESC)
+  final val openApiReservedWordsMappings = settingKey[Map[String, String]](
+    "Specifies how a reserved name should be escaped to."
+  )
+  final val openApiIgnoreFileOverride =
+    settingKey[String](CodegenConstants.IGNORE_FILE_OVERRIDE_DESC)
+  final val openApiRemoveOperationIdPrefix = settingKey[Option[Boolean]](
+    "Remove prefix of operationId, e.g. config_getId => getId"
+  )
 
-  /**
-   * Defines which API-related files should be generated. This allows you to create a subset of generated files (or none at all).
-   *
-   * This option enables/disables generation of ALL api-related files.
-   *
-   * NOTE: Configuring any one of [apiFilesConstrainedTo], [modelFilesConstrainedTo], or [supportingFilesConstrainedTo] results
-   * in others being disabled. That is, OpenAPI Generator considers any one of these to define a subset of generation.
-   * For more control over generation of individual files, configure an ignore file and refer to it via [ignoreFileOverride].
-   */
-  final val openApiApiFilesConstrainedTo = settingKey[List[String]]("Defines which API-related files should be generated. This allows you to create a subset of generated files (or none at all).")
+  /** Defines which API-related files should be generated. This allows you to
+    * create a subset of generated files (or none at all).
+    *
+    * This option enables/disables generation of ALL api-related files.
+    *
+    * NOTE: Configuring any one of [apiFilesConstrainedTo],
+    * [modelFilesConstrainedTo], or [supportingFilesConstrainedTo] results in
+    * others being disabled. That is, OpenAPI Generator considers any one of
+    * these to define a subset of generation. For more control over generation
+    * of individual files, configure an ignore file and refer to it via
+    * [ignoreFileOverride].
+    */
+  final val openApiApiFilesConstrainedTo = settingKey[List[String]](
+    "Defines which API-related files should be generated. This allows you to create a subset of generated files (or none at all)."
+  )
 
-  /**
-   * Defines which model-related files should be generated. This allows you to create a subset of generated files (or none at all).
-   *
-   * NOTE: Configuring any one of [apiFilesConstrainedTo], [modelFilesConstrainedTo], or [supportingFilesConstrainedTo] results
-   * in others being disabled. That is, OpenAPI Generator considers any one of these to define a subset of generation.
-   * For more control over generation of individual files, configure an ignore file and refer to it via [ignoreFileOverride].
-   */
-  final val openApiModelFilesConstrainedTo = settingKey[List[String]]("Defines which model-related files should be generated. This allows you to create a subset of generated files (or none at all).")
+  /** Defines which model-related files should be generated. This allows you to
+    * create a subset of generated files (or none at all).
+    *
+    * NOTE: Configuring any one of [apiFilesConstrainedTo],
+    * [modelFilesConstrainedTo], or [supportingFilesConstrainedTo] results in
+    * others being disabled. That is, OpenAPI Generator considers any one of
+    * these to define a subset of generation. For more control over generation
+    * of individual files, configure an ignore file and refer to it via
+    * [ignoreFileOverride].
+    */
+  final val openApiModelFilesConstrainedTo = settingKey[List[String]](
+    "Defines which model-related files should be generated. This allows you to create a subset of generated files (or none at all)."
+  )
 
-  /**
-   * Defines which supporting files should be generated. This allows you to create a subset of generated files (or none at all).
-   *
-   * Supporting files are those related to projects/frameworks which may be modified
-   * by consumers.
-   *
-   * NOTE: Configuring any one of [apiFilesConstrainedTo], [modelFilesConstrainedTo], or [supportingFilesConstrainedTo] results
-   * in others being disabled. That is, OpenAPI Generator considers any one of these to define a subset of generation.
-   * For more control over generation of individual files, configure an ignore file and refer to it via [ignoreFileOverride].
-   */
-  final val openApiSupportingFilesConstrainedTo = settingKey[List[String]]("Defines which supporting files should be generated. This allows you to create a subset of generated files (or none at all).")
+  /** Defines which supporting files should be generated. This allows you to
+    * create a subset of generated files (or none at all).
+    *
+    * Supporting files are those related to projects/frameworks which may be
+    * modified by consumers.
+    *
+    * NOTE: Configuring any one of [apiFilesConstrainedTo],
+    * [modelFilesConstrainedTo], or [supportingFilesConstrainedTo] results in
+    * others being disabled. That is, OpenAPI Generator considers any one of
+    * these to define a subset of generation. For more control over generation
+    * of individual files, configure an ignore file and refer to it via
+    * [ignoreFileOverride].
+    */
+  final val openApiSupportingFilesConstrainedTo = settingKey[List[String]](
+    "Defines which supporting files should be generated. This allows you to create a subset of generated files (or none at all)."
+  )
 
-  /**
-   * Defines whether or not model-related _test_ files should be generated.
-   *
-   * This option enables/disables generation of ALL model-related _test_ files.
-   *
-   * For more control over generation of individual files, configure an ignore file and
-   * refer to it via [ignoreFileOverride].
-   */
-  final val openApiGenerateModelTests = settingKey[Option[Boolean]](CodegenConstants.GENERATE_MODEL_TESTS_DESC)
+  /** Defines whether or not model-related _test_ files should be generated.
+    *
+    * This option enables/disables generation of ALL model-related _test_ files.
+    *
+    * For more control over generation of individual files, configure an ignore
+    * file and refer to it via [ignoreFileOverride].
+    */
+  final val openApiGenerateModelTests =
+    settingKey[Option[Boolean]](CodegenConstants.GENERATE_MODEL_TESTS_DESC)
 
-  /**
-   * Defines whether or not model-related _documentation_ files should be generated.
-   *
-   * This option enables/disables generation of ALL model-related _documentation_ files.
-   *
-   * For more control over generation of individual files, configure an ignore file and
-   * refer to it via [ignoreFileOverride].
-   */
-  final val openApiGenerateModelDocumentation = settingKey[Option[Boolean]]("Defines whether or not model-related _documentation_ files should be generated.")
+  /** Defines whether or not model-related _documentation_ files should be
+    * generated.
+    *
+    * This option enables/disables generation of ALL model-related
+    * _documentation_ files.
+    *
+    * For more control over generation of individual files, configure an ignore
+    * file and refer to it via [ignoreFileOverride].
+    */
+  final val openApiGenerateModelDocumentation = settingKey[Option[Boolean]](
+    "Defines whether or not model-related _documentation_ files should be generated."
+  )
 
-  /**
-   * Defines whether or not api-related _test_ files should be generated.
-   *
-   * This option enables/disables generation of ALL api-related _test_ files.
-   *
-   * For more control over generation of individual files, configure an ignore file and
-   * refer to it via [ignoreFileOverride].
-   */
-  final val openApiGenerateApiTests = settingKey[Option[Boolean]](CodegenConstants.GENERATE_API_TESTS_DESC)
+  /** Defines whether or not api-related _test_ files should be generated.
+    *
+    * This option enables/disables generation of ALL api-related _test_ files.
+    *
+    * For more control over generation of individual files, configure an ignore
+    * file and refer to it via [ignoreFileOverride].
+    */
+  final val openApiGenerateApiTests =
+    settingKey[Option[Boolean]](CodegenConstants.GENERATE_API_TESTS_DESC)
 
-  /**
-   * Defines whether or not api-related _documentation_ files should be generated.
-   *
-   * This option enables/disables generation of ALL api-related _documentation_ files.
-   *
-   * For more control over generation of individual files, configure an ignore file and
-   * refer to it via [ignoreFileOverride].
-   */
-  final val openApiGenerateApiDocumentation = settingKey[Option[Boolean]]("Defines whether or not api-related _documentation_ files should be generated.")
-  final val openApiWithXml = settingKey[Option[Boolean]]("A special-case setting which configures some generators with XML support. In some cases, this forces json OR xml, so the default here is false.")
+  /** Defines whether or not api-related _documentation_ files should be
+    * generated.
+    *
+    * This option enables/disables generation of ALL api-related _documentation_
+    * files.
+    *
+    * For more control over generation of individual files, configure an ignore
+    * file and refer to it via [ignoreFileOverride].
+    */
+  final val openApiGenerateApiDocumentation = settingKey[Option[Boolean]](
+    "Defines whether or not api-related _documentation_ files should be generated."
+  )
+  final val openApiWithXml = settingKey[Option[Boolean]](
+    "A special-case setting which configures some generators with XML support. In some cases, this forces json OR xml, so the default here is false."
+  )
 
-  final val openApiLogToStderr = settingKey[Option[Boolean]]("To write all log messages (not just errors) to STDOUT")
+  final val openApiLogToStderr = settingKey[Option[Boolean]](
+    "To write all log messages (not just errors) to STDOUT"
+  )
 
-  /**
-   * To enable the file post-processing hook. This enables executing an external post-processor (usually a linter program).
-   * This only enables the post-processor. To define the post-processing command, define an environment variable such as
-   * LANG_POST_PROCESS_FILE (e.g. GO_POST_PROCESS_FILE, SCALA_POST_PROCESS_FILE). Please open an issue if your target
-   * generator does not support this functionality.
-   */
-  final val openApiEnablePostProcessFile = settingKey[Option[Boolean]](CodegenConstants.ENABLE_POST_PROCESS_FILE_DESC)
+  /** To enable the file post-processing hook. This enables executing an
+    * external post-processor (usually a linter program). This only enables the
+    * post-processor. To define the post-processing command, define an
+    * environment variable such as LANG_POST_PROCESS_FILE (e.g.
+    * GO_POST_PROCESS_FILE, SCALA_POST_PROCESS_FILE). Please open an issue if
+    * your target generator does not support this functionality.
+    */
+  final val openApiEnablePostProcessFile =
+    settingKey[Option[Boolean]](CodegenConstants.ENABLE_POST_PROCESS_FILE_DESC)
 
-  final val openApiSkipValidateSpec = settingKey[Option[Boolean]]("To skip spec validation. When true, we will skip the default behavior of validating a spec before generation.")
+  final val openApiSkipValidateSpec = settingKey[Option[Boolean]](
+    "To skip spec validation. When true, we will skip the default behavior of validating a spec before generation."
+  )
 
-  /**
-   * To generate alias (array, list, map) as model. When false, top-level objects defined as array, list, or map will result in those
-   * definitions generated as top-level Array-of-items, List-of-items, Map-of-items definitions.
-   * When true, A model representation either containing or extending the array,list,map (depending on specific generator implementation) will be generated.
-   */
-  final val openApiGenerateAliasAsModel = settingKey[Option[Boolean]](CodegenConstants.GENERATE_ALIAS_AS_MODEL_DESC)
+  /** To generate alias (array, list, map) as model. When false, top-level
+    * objects defined as array, list, or map will result in those definitions
+    * generated as top-level Array-of-items, List-of-items, Map-of-items
+    * definitions. When true, A model representation either containing or
+    * extending the array,list,map (depending on specific generator
+    * implementation) will be generated.
+    */
+  final val openApiGenerateAliasAsModel =
+    settingKey[Option[Boolean]](CodegenConstants.GENERATE_ALIAS_AS_MODEL_DESC)
 
-  /**
-   * Indicate whether or not to generate OpenAPI Generator metadata files.
-   * These files include .openapi-generator/VERSION, .openapi-generator-ignore, and any other metadata files
-   * used by OpenAPI Generator.
-   */
-  final val openApiGenerateMetadata = settingKey[Option[Boolean]]("Generate metadata files used by OpenAPI Generator. This includes .openapi-generator-ignore and any files within .openapi-generator.")
+  /** Indicate whether or not to generate OpenAPI Generator metadata files.
+    * These files include .openapi-generator/VERSION, .openapi-generator-ignore,
+    * and any other metadata files used by OpenAPI Generator.
+    */
+  final val openApiGenerateMetadata = settingKey[Option[Boolean]](
+    "Generate metadata files used by OpenAPI Generator. This includes .openapi-generator-ignore and any files within .openapi-generator."
+  )
 
 }

--- a/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorPlugin.scala
+++ b/src/main/scala/org/openapitools/generator/sbt/plugin/OpenApiGeneratorPlugin.scala
@@ -17,14 +17,19 @@
 
 package org.openapitools.generator.sbt.plugin
 
-import org.openapitools.generator.sbt.plugin.tasks.{OpenApiGenerateTask, OpenApiGeneratorsTask}
+import org.openapitools.generator.sbt.plugin.tasks.OpenApiGenerateTask
+import org.openapitools.generator.sbt.plugin.tasks.OpenApiGeneratorsTask
+import sbt.Def
+import sbt.File
 import sbt.Keys.aggregate
+import sbt.config
 import sbt.plugins.JvmPlugin
-import sbt.{Def, File, config, taskKey}
+import sbt.taskKey
 
-object OpenApiGeneratorPlugin extends sbt.AutoPlugin
-  with OpenApiGeneratorsTask
-  with OpenApiGenerateTask {
+object OpenApiGeneratorPlugin
+    extends sbt.AutoPlugin
+    with OpenApiGeneratorsTask
+    with OpenApiGenerateTask {
   self =>
 
   override def requires: JvmPlugin.type = sbt.plugins.JvmPlugin
@@ -37,7 +42,6 @@ object OpenApiGeneratorPlugin extends sbt.AutoPlugin
 
     def SettingDisabled: Option[Boolean] = Some(false)
 
-
   }
 
   val out = taskKey[Seq[File]]("Out")
@@ -45,7 +49,7 @@ object OpenApiGeneratorPlugin extends sbt.AutoPlugin
   val OpenApiCodegen = config("openApiCodegen")
 
   override def globalSettings: Seq[Def.Setting[?]] = Seq(
-    aggregate in openApiGenerators := false
+    openApiGenerators / aggregate := false
   )
 
   private lazy val baseSettings: Seq[sbt.Setting[?]] = Seq[sbt.Setting[?]](

--- a/src/main/scala/org/openapitools/generator/sbt/plugin/tasks/OpenApiGenerateTask.scala
+++ b/src/main/scala/org/openapitools/generator/sbt/plugin/tasks/OpenApiGenerateTask.scala
@@ -16,258 +16,285 @@
  */
 package org.openapitools.generator.sbt.plugin.tasks
 
-import org.openapitools.codegen.config.{CodegenConfigurator, GlobalSettings}
-import org.openapitools.codegen.{CodegenConstants, DefaultGenerator}
+import org.openapitools.codegen.CodegenConstants
+import org.openapitools.codegen.DefaultGenerator
+import org.openapitools.codegen.config.CodegenConfigurator
+import org.openapitools.codegen.config.GlobalSettings
 import org.openapitools.generator.sbt.plugin.OpenApiGeneratorKeys
+import sbt._
+import sbt.Def
 import sbt.Keys._
-import sbt.{Def, _}
 
 import scala.collection.JavaConverters._
-import scala.util.{Failure, Success, Try}
+import scala.util.Failure
+import scala.util.Success
+import scala.util.Try
 
 trait OpenApiGenerateTask extends OpenApiGeneratorKeys {
 
-  protected[this] def openApiGenerateTask: Def.Initialize[Task[Seq[File]]] = Def.task {
+  protected def openApiGenerateTask: Def.Initialize[Task[Seq[File]]] =
+    Def.task {
 
-    val logger = sbt.Keys.streams.value.log
+      val logger = sbt.Keys.streams.value.log
 
-    if (openApiConfigFile.value.isEmpty && openApiGeneratorName.value.isEmpty) {
-      Seq()
-    } else {
-      val configurator: CodegenConfigurator = if (openApiConfigFile.value.nonEmpty) {
-        val config = openApiConfigFile.value
-        logger.info(s"read configuration from $config")
-        CodegenConfigurator.fromFile(config)
-      } else new CodegenConfigurator()
-
-      if (openApiSupportingFilesConstrainedTo.value.nonEmpty) {
-        GlobalSettings.setProperty(CodegenConstants.SUPPORTING_FILES, openApiSupportingFilesConstrainedTo.value.mkString(","))
+      if (
+        openApiConfigFile.value.isEmpty && openApiGeneratorName.value.isEmpty
+      ) {
+        Seq()
       } else {
-        GlobalSettings.clearProperty(CodegenConstants.SUPPORTING_FILES)
-      }
+        val configurator: CodegenConfigurator =
+          if (openApiConfigFile.value.nonEmpty) {
+            val config = openApiConfigFile.value
+            logger.info(s"read configuration from $config")
+            CodegenConfigurator.fromFile(config)
+          } else new CodegenConfigurator()
 
-      if (openApiModelFilesConstrainedTo.value.nonEmpty) {
-        GlobalSettings.setProperty(CodegenConstants.MODELS, openApiModelFilesConstrainedTo.value.mkString(","))
-      } else {
-        GlobalSettings.clearProperty(CodegenConstants.MODELS)
-      }
-
-      if (openApiApiFilesConstrainedTo.value.nonEmpty) {
-        GlobalSettings.setProperty(CodegenConstants.APIS, openApiApiFilesConstrainedTo.value.mkString(","))
-      } else {
-        GlobalSettings.clearProperty(CodegenConstants.APIS)
-      }
-
-      openApiGenerateApiDocumentation.value.foreach { value =>
-        GlobalSettings.setProperty(CodegenConstants.API_DOCS, value.toString)
-      }
-
-      openApiGenerateModelDocumentation.value.foreach { value =>
-        GlobalSettings.setProperty(CodegenConstants.MODEL_DOCS, value.toString)
-      }
-
-      openApiGenerateModelTests.value.foreach { value =>
-        GlobalSettings.setProperty(CodegenConstants.MODEL_TESTS, value.toString)
-      }
-
-      openApiGenerateApiTests.value.foreach { value =>
-        GlobalSettings.setProperty(CodegenConstants.API_TESTS, value.toString)
-      }
-
-      openApiWithXml.value.foreach { value =>
-        GlobalSettings.setProperty(CodegenConstants.WITH_XML, value.toString)
-      }
-
-      // now override with any specified parameters
-      openApiVerbose.value.foreach { value =>
-        configurator.setVerbose(value)
-      }
-      openApiValidateSpec.value.foreach { value =>
-        configurator.setValidateSpec(value)
-      }
-
-      openApiSkipOverwrite.value.foreach { value =>
-        configurator.setSkipOverwrite(value)
-      }
-
-      if (openApiInputSpec.value.nonEmpty) {
-        configurator.setInputSpec(openApiInputSpec.value)
-      }
-
-
-      if (openApiGeneratorName.value.nonEmpty) {
-        configurator.setGeneratorName(openApiGeneratorName.value)
-      }
-
-      if (openApiOutputDir.value.nonEmpty) {
-        configurator.setOutputDir(openApiOutputDir.value)
-      }
-
-      if (openApiAuth.value.nonEmpty) {
-        configurator.setAuth(openApiAuth.value)
-      }
-
-      if (openApiTemplateDir.value.nonEmpty) {
-        configurator.setTemplateDir(openApiTemplateDir.value)
-      }
-
-      if (openApiPackageName.value.nonEmpty) {
-        configurator.setPackageName(openApiPackageName.value)
-      }
-
-      if (openApiApiPackage.value.nonEmpty) {
-        configurator.setApiPackage(openApiApiPackage.value)
-      }
-
-      if (openApiModelPackage.value.nonEmpty) {
-        configurator.setModelPackage(openApiModelPackage.value)
-      }
-
-      if (openApiModelNamePrefix.value.nonEmpty) {
-        configurator.setModelNamePrefix(openApiModelNamePrefix.value)
-      }
-
-      if (openApiModelNameSuffix.value.nonEmpty) {
-        configurator.setModelNameSuffix(openApiModelNameSuffix.value)
-      }
-
-      if (openApiInvokerPackage.value.nonEmpty) {
-        configurator.setInvokerPackage(openApiInvokerPackage.value)
-      }
-
-      if (openApiGroupId.value.nonEmpty) {
-        configurator.setGroupId(openApiGroupId.value)
-      }
-
-      if (openApiId.value.nonEmpty) {
-        configurator.setArtifactId(openApiId.value)
-      }
-
-      if ((version in openApiGenerate).value.nonEmpty) {
-        configurator.setArtifactVersion(version.value)
-      }
-
-      if (openApiLibrary.value.nonEmpty) {
-        configurator.setLibrary(openApiLibrary.value)
-      }
-
-      if (openApiGitHost.value.nonEmpty) {
-        configurator.setGitHost(openApiGitHost.value)
-      }
-
-      if (openApiGitUserId.value.nonEmpty) {
-        configurator.setGitUserId(openApiGitUserId.value)
-      }
-
-
-      if (openApiGitRepoId.value.nonEmpty) {
-        configurator.setGitRepoId(openApiGitRepoId.value)
-      }
-
-      if (openApiReleaseNote.value.nonEmpty) {
-        configurator.setReleaseNote(openApiReleaseNote.value)
-      }
-
-      if (openApiHttpUserAgent.value.nonEmpty) {
-        configurator.setHttpUserAgent(openApiHttpUserAgent.value)
-      }
-
-      if (openApiIgnoreFileOverride.value.nonEmpty) {
-        configurator.setIgnoreFileOverride(openApiIgnoreFileOverride.value)
-      }
-
-      openApiRemoveOperationIdPrefix.value.foreach { value =>
-        configurator.setRemoveOperationIdPrefix(value)
-      }
-
-      openApiLogToStderr.value.foreach { value =>
-        configurator.setLogToStderr(value)
-      }
-
-      openApiEnablePostProcessFile.value.foreach { value =>
-        configurator.setEnablePostProcessFile(value)
-      }
-
-      openApiSkipValidateSpec.value.foreach { value =>
-        configurator.setValidateSpec(!value)
-      }
-
-      openApiGenerateAliasAsModel.value.foreach { value =>
-        configurator.setGenerateAliasAsModel(value)
-      }
-
-      if (openApiGlobalProperties.value.nonEmpty || openApiSystemProperties.value.nonEmpty) {
-        (openApiSystemProperties.value ++ openApiGlobalProperties.value).foreach { entry =>
-          configurator.addGlobalProperty(entry._1, entry._2)
+        if (openApiSupportingFilesConstrainedTo.value.nonEmpty) {
+          GlobalSettings.setProperty(
+            CodegenConstants.SUPPORTING_FILES,
+            openApiSupportingFilesConstrainedTo.value.mkString(",")
+          )
+        } else {
+          GlobalSettings.clearProperty(CodegenConstants.SUPPORTING_FILES)
         }
-      }
 
-      if (openApiInstantiationTypes.value.nonEmpty) {
-        openApiInstantiationTypes.value.foreach { entry =>
-          configurator.addInstantiationType(entry._1, entry._2)
+        if (openApiModelFilesConstrainedTo.value.nonEmpty) {
+          GlobalSettings.setProperty(
+            CodegenConstants.MODELS,
+            openApiModelFilesConstrainedTo.value.mkString(",")
+          )
+        } else {
+          GlobalSettings.clearProperty(CodegenConstants.MODELS)
         }
-      }
 
-      if (openApiImportMappings.value.nonEmpty) {
-        openApiImportMappings.value.foreach { entry =>
-          configurator.addImportMapping(entry._1, entry._2)
+        if (openApiApiFilesConstrainedTo.value.nonEmpty) {
+          GlobalSettings.setProperty(
+            CodegenConstants.APIS,
+            openApiApiFilesConstrainedTo.value.mkString(",")
+          )
+        } else {
+          GlobalSettings.clearProperty(CodegenConstants.APIS)
         }
-      }
 
-      if (openApiTypeMappings.value.nonEmpty) {
-        openApiTypeMappings.value.foreach { entry =>
-          configurator.addTypeMapping(entry._1, entry._2)
+        openApiGenerateApiDocumentation.value.foreach { value =>
+          GlobalSettings.setProperty(CodegenConstants.API_DOCS, value.toString)
         }
-      }
 
-      if (openApiAdditionalProperties.value.nonEmpty) {
-        openApiAdditionalProperties.value.foreach { entry =>
-          configurator.addAdditionalProperty(entry._1, entry._2)
+        openApiGenerateModelDocumentation.value.foreach { value =>
+          GlobalSettings.setProperty(
+            CodegenConstants.MODEL_DOCS,
+            value.toString
+          )
         }
-      }
 
-      if (openApiServerVariables.value.nonEmpty) {
-        openApiServerVariables.value.foreach { entry =>
-          configurator.addServerVariable(entry._1, entry._2)
+        openApiGenerateModelTests.value.foreach { value =>
+          GlobalSettings.setProperty(
+            CodegenConstants.MODEL_TESTS,
+            value.toString
+          )
         }
-      }
 
-      if (openApiLanguageSpecificPrimitives.value.nonEmpty) {
-        openApiLanguageSpecificPrimitives.value.foreach { it =>
-          configurator.addLanguageSpecificPrimitive(it)
+        openApiGenerateApiTests.value.foreach { value =>
+          GlobalSettings.setProperty(CodegenConstants.API_TESTS, value.toString)
         }
-      }
 
-      if (openApiReservedWordsMappings.value.nonEmpty) {
-        openApiReservedWordsMappings.value.foreach { entry =>
-          configurator.addAdditionalReservedWordMapping(entry._1, entry._2)
+        openApiWithXml.value.foreach { value =>
+          GlobalSettings.setProperty(CodegenConstants.WITH_XML, value.toString)
         }
-      }
 
-      Try(configurator.toClientOptInput) match {
-        case Success(clientOptInput) =>
-          Try {
-            val gen = new DefaultGenerator()
+        // now override with any specified parameters
+        openApiVerbose.value.foreach { value =>
+          configurator.setVerbose(value)
+        }
+        openApiValidateSpec.value.foreach { value =>
+          configurator.setValidateSpec(value)
+        }
 
-            gen.opts(clientOptInput)
+        openApiSkipOverwrite.value.foreach { value =>
+          configurator.setSkipOverwrite(value)
+        }
 
-            openApiGenerateMetadata.value.foreach { value =>
-              gen.setGenerateMetadata(value)
+        if (openApiInputSpec.value.nonEmpty) {
+          configurator.setInputSpec(openApiInputSpec.value)
+        }
+
+        if (openApiGeneratorName.value.nonEmpty) {
+          configurator.setGeneratorName(openApiGeneratorName.value)
+        }
+
+        if (openApiOutputDir.value.nonEmpty) {
+          configurator.setOutputDir(openApiOutputDir.value)
+        }
+
+        if (openApiAuth.value.nonEmpty) {
+          configurator.setAuth(openApiAuth.value)
+        }
+
+        if (openApiTemplateDir.value.nonEmpty) {
+          configurator.setTemplateDir(openApiTemplateDir.value)
+        }
+
+        if (openApiPackageName.value.nonEmpty) {
+          configurator.setPackageName(openApiPackageName.value)
+        }
+
+        if (openApiApiPackage.value.nonEmpty) {
+          configurator.setApiPackage(openApiApiPackage.value)
+        }
+
+        if (openApiModelPackage.value.nonEmpty) {
+          configurator.setModelPackage(openApiModelPackage.value)
+        }
+
+        if (openApiModelNamePrefix.value.nonEmpty) {
+          configurator.setModelNamePrefix(openApiModelNamePrefix.value)
+        }
+
+        if (openApiModelNameSuffix.value.nonEmpty) {
+          configurator.setModelNameSuffix(openApiModelNameSuffix.value)
+        }
+
+        if (openApiInvokerPackage.value.nonEmpty) {
+          configurator.setInvokerPackage(openApiInvokerPackage.value)
+        }
+
+        if (openApiGroupId.value.nonEmpty) {
+          configurator.setGroupId(openApiGroupId.value)
+        }
+
+        if (openApiId.value.nonEmpty) {
+          configurator.setArtifactId(openApiId.value)
+        }
+
+        if ((openApiGenerate / version).value.nonEmpty) {
+          configurator.setArtifactVersion(version.value)
+        }
+
+        if (openApiLibrary.value.nonEmpty) {
+          configurator.setLibrary(openApiLibrary.value)
+        }
+
+        if (openApiGitHost.value.nonEmpty) {
+          configurator.setGitHost(openApiGitHost.value)
+        }
+
+        if (openApiGitUserId.value.nonEmpty) {
+          configurator.setGitUserId(openApiGitUserId.value)
+        }
+
+        if (openApiGitRepoId.value.nonEmpty) {
+          configurator.setGitRepoId(openApiGitRepoId.value)
+        }
+
+        if (openApiReleaseNote.value.nonEmpty) {
+          configurator.setReleaseNote(openApiReleaseNote.value)
+        }
+
+        if (openApiHttpUserAgent.value.nonEmpty) {
+          configurator.setHttpUserAgent(openApiHttpUserAgent.value)
+        }
+
+        if (openApiIgnoreFileOverride.value.nonEmpty) {
+          configurator.setIgnoreFileOverride(openApiIgnoreFileOverride.value)
+        }
+
+        openApiRemoveOperationIdPrefix.value.foreach { value =>
+          configurator.setRemoveOperationIdPrefix(value)
+        }
+
+        openApiLogToStderr.value.foreach { value =>
+          configurator.setLogToStderr(value)
+        }
+
+        openApiEnablePostProcessFile.value.foreach { value =>
+          configurator.setEnablePostProcessFile(value)
+        }
+
+        openApiSkipValidateSpec.value.foreach { value =>
+          configurator.setValidateSpec(!value)
+        }
+
+        openApiGenerateAliasAsModel.value.foreach { value =>
+          configurator.setGenerateAliasAsModel(value)
+        }
+
+        if (
+          openApiGlobalProperties.value.nonEmpty || openApiSystemProperties.value.nonEmpty
+        ) {
+          (openApiSystemProperties.value ++ openApiGlobalProperties.value)
+            .foreach { entry =>
+              configurator.addGlobalProperty(entry._1, entry._2)
             }
+        }
 
-            val res = gen.generate().asScala
-
-            logger.info(s"Successfully generated code to ${clientOptInput.getConfig.getOutputDir}")
-            res
-          } match {
-            case Success(value) => value
-            case Failure(ex) =>
-              throw new Exception("Code generation failed.", ex)
+        if (openApiInstantiationTypes.value.nonEmpty) {
+          openApiInstantiationTypes.value.foreach { entry =>
+            configurator.addInstantiationType(entry._1, entry._2)
           }
-        case Failure(ex) =>
-          logger.error(ex.getMessage)
-          Seq.empty
+        }
+
+        if (openApiImportMappings.value.nonEmpty) {
+          openApiImportMappings.value.foreach { entry =>
+            configurator.addImportMapping(entry._1, entry._2)
+          }
+        }
+
+        if (openApiTypeMappings.value.nonEmpty) {
+          openApiTypeMappings.value.foreach { entry =>
+            configurator.addTypeMapping(entry._1, entry._2)
+          }
+        }
+
+        if (openApiAdditionalProperties.value.nonEmpty) {
+          openApiAdditionalProperties.value.foreach { entry =>
+            configurator.addAdditionalProperty(entry._1, entry._2)
+          }
+        }
+
+        if (openApiServerVariables.value.nonEmpty) {
+          openApiServerVariables.value.foreach { entry =>
+            configurator.addServerVariable(entry._1, entry._2)
+          }
+        }
+
+        if (openApiLanguageSpecificPrimitives.value.nonEmpty) {
+          openApiLanguageSpecificPrimitives.value.foreach { it =>
+            configurator.addLanguageSpecificPrimitive(it)
+          }
+        }
+
+        if (openApiReservedWordsMappings.value.nonEmpty) {
+          openApiReservedWordsMappings.value.foreach { entry =>
+            configurator.addAdditionalReservedWordMapping(entry._1, entry._2)
+          }
+        }
+
+        Try(configurator.toClientOptInput) match {
+          case Success(clientOptInput) =>
+            Try {
+              val gen = new DefaultGenerator()
+
+              gen.opts(clientOptInput)
+
+              openApiGenerateMetadata.value.foreach { value =>
+                gen.setGenerateMetadata(value)
+              }
+
+              val res = gen.generate().asScala.toSeq
+
+              logger.info(
+                s"Successfully generated code to ${clientOptInput.getConfig.getOutputDir}"
+              )
+              res
+            } match {
+              case Success(value) => value.toSeq
+              case Failure(ex)    =>
+                throw new Exception("Code generation failed.", ex)
+            }
+          case Failure(ex) =>
+            logger.error(ex.getMessage)
+            Seq.empty
+        }
       }
     }
-  }
 }

--- a/src/main/scala/org/openapitools/generator/sbt/plugin/tasks/OpenApiGeneratorsTask.scala
+++ b/src/main/scala/org/openapitools/generator/sbt/plugin/tasks/OpenApiGeneratorsTask.scala
@@ -21,11 +21,11 @@ import org.openapitools.codegen.meta.Stability
 import org.openapitools.codegen.{CodegenConfigLoader, CodegenType}
 import sbt.{Def, Task}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 trait OpenApiGeneratorsTask {
 
-  protected[this] def openApiGeneratorsTask: Def.Initialize[Task[Unit]] = Def.task {
+  protected def openApiGeneratorsTask: Def.Initialize[Task[Unit]] = Def.task {
     val generators = CodegenConfigLoader.getAll.asScala
     val types = CodegenType.values()
 
@@ -37,21 +37,21 @@ trait OpenApiGeneratorsTask {
 
     out ++= "The following generators are available:" + System.lineSeparator()
     for (t <- types) {
-      val filteredGenerators = generators.filter(_.getTag == t).sortBy(_.getName)
+      val filteredGenerators =
+        generators.filter(_.getTag == t).sortBy(_.getName)
       if (filteredGenerators.nonEmpty) {
         out ++= s" $t generators:" + System.lineSeparator()
-        filteredGenerators.foreach {
-          generator =>
-            val meta = generator.getGeneratorMetadata
-            val stability = meta.getStability
-            val include = stabilities.contains(stability)
-            if (include) {
-              out ++= s"    - ${generator.getName}"
-              if (stability != Stability.STABLE) {
-                out ++= s" (${stability.value()})"
-              }
-              out ++= System.lineSeparator()
+        filteredGenerators.foreach { generator =>
+          val meta = generator.getGeneratorMetadata
+          val stability = meta.getStability
+          val include = stabilities.contains(stability)
+          if (include) {
+            out ++= s"    - ${generator.getName}"
+            if (stability != Stability.STABLE) {
+              out ++= s" (${stability.value()})"
             }
+            out ++= System.lineSeparator()
+          }
         }
       }
     }

--- a/src/sbt-test/sbt-openapi-generator/simple/build.sbt
+++ b/src/sbt-test/sbt-openapi-generator/simple/build.sbt
@@ -2,7 +2,8 @@ scalaVersion := "2.12.10"
 
 externalResolvers += Resolver.sonatypeRepo("snapshots")
 
-lazy val generated = project.in(file("generated"))
+lazy val generated = project
+  .in(file("generated"))
   .enablePlugins(OpenApiGeneratorPlugin)
   .settings(
     openApiInputSpec := "openapi.yaml",

--- a/src/sbt-test/sbt-openapi-generator/simple/project/plugin.sbt
+++ b/src/sbt-test/sbt-openapi-generator/simple/project/plugin.sbt
@@ -3,6 +3,6 @@ resolvers ++= Seq(
 )
 sys.props.get("plugin.version") match {
   case Some(x) => addSbtPlugin("org.openapitools" % "sbt-openapi-generator" % x)
-  case _ =>
+  case _       =>
     throw new Exception("The system property 'plugin.version' is not defined.")
 }


### PR DESCRIPTION
update sbt 1.x to 1.12.10, make project compile against 2.0.0-RC12:
- update build sbt: 1.11.4 -> 1.12.10
- update sbt 1.x cross-build version: 1.5.8 -> 1.12.10
- update sbt 2.x cross-build version: 2.0.0-RC3 -> 2.0.0-RC12
- migrate scoped keys to slash syntax (x in y -> y / x)
- replace deprecated scala.collection.JavaConverters with scala.jdk.CollectionConverters
- annotate openApiGenerate as @transient so sbt 2.x skips caching its Seq[File]
  output (no-op under sbt 1.x)
- reformat touched files (no behavioral change)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the build to `sbt` 1.12.10 and enable cross-build on `sbt` 2.0.0-RC12. Migrate to slash syntax and remove deprecated APIs to keep behavior the same on 1.x and 2.x.

- **Dependencies**
  - Update root `sbt.version`: 1.11.4 → 1.12.10.
  - Update cross-build: `pluginCrossBuild / sbtVersion` 1.5.8 → 1.12.10 (Scala 2.12), 2.0.0-RC3 → 2.0.0-RC12 (others).

- **Refactors**
  - Migrate scoped keys to `task / key` (e.g., `openApiGenerators / aggregate`, `openApiGenerate / version`).
  - Replace `scala.collection.JavaConverters` with `scala.jdk.CollectionConverters`.
  - Annotate `openApiGenerate` with `@transient` to skip task output caching on `sbt` 2.x.

<sup>Written for commit d3d0e137f452a144f0a776888ed039c716baf235. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/sbt-openapi-generator/pull/86?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

