### PR TITLE
build: cross-publish plugin for sbt 1 and sbt 2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 8
+          java-version: 17
           cache: sbt
       - uses: sbt/setup-sbt@v1
       - run: sbt ci-release

--- a/.github/workflows/sbt.yml
+++ b/.github/workflows/sbt.yml
@@ -8,13 +8,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 17
           distribution: temurin
       - name: Setup sbt launcher
         uses: sbt/setup-sbt@v1
@@ -29,5 +29,4 @@ jobs:
           path: ~/.sbt
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/*.sbt') }}
       - name: Build
-        run: sbt compile
-        #run: sbt ^test ^scripted
+        run: sbt +test +scripted

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ specifications as part of your build. Other tasks are available as command line 
 """
 
 lazy val scala21220 = "2.12.20"
-lazy val scala372 = "3.7.2"
+lazy val scala384 = "3.8.4"
 
 onLoadMessage := s"Welcome to sbt-openapi-generator ${version.value}"
 //crossScalaVersions := Nil
@@ -38,19 +38,18 @@ lazy val `sbt-openapi-generator` = (project in file("."))
       )
     ),
     moduleName := "sbt-openapi-generator",
-    crossScalaVersions := Seq(scala21220),
-    // crossScalaVersions := Seq(scala21220, scala372),
+    crossScalaVersions := Seq(scala21220, scala384),
     sbtPlugin := true,
     scalacOptions ++= {
       scalaBinaryVersion.value match {
-        case "2.12" => "-Xsource:3" :: Nil
-        case _      => Nil
+        case "2.12" => Seq("-Xsource:3", "-release:11")
+        case _      => Seq("-release:17")
       }
     },
     (pluginCrossBuild / sbtVersion) := {
       scalaBinaryVersion.value match {
-        case "2.12" => "1.12.10"
-        case _      => "2.0.0-RC12"
+        case "2.12" => "1.12.11"
+        case _      => "2.0.0"
       }
     },
     scriptedLaunchOpts := {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.10
+sbt.version=1.12.11


### PR DESCRIPTION
Enable cross-building so the plugin publishes against both
sbt 1.x (Scala 2.12) and sbt 2.x (Scala 3), and align the CI/
release workflows with sbt 2's JDK 17 requirement.

build.sbt:
- crossScalaVersions := Seq(2.12.20, 3.8.4)
- set bytecode floors via -release (2.12 -> 11, Scala 3 -> 17)
- sbt 2.x target 2.0.0-RC12 -> 2.0.0
- sbt 1.x target / build sbt 1.12.10 -> 1.12.11
- bump Scala 3 3.7.2 -> 3.8.4

CI:
- release & build workflows: Java 8/11 -> 17 (sbt 2 needs 17+)
- update checkout@v6 / setup-java@v5
- build step runs +test +scripted across both Scala axes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cross-publish the `sbt-openapi-generator` plugin for sbt 1.x (Scala 2.12) and sbt 2.x (Scala 3). Align CI and bytecode targets with sbt 2’s JDK 17 requirements.

- **Build & CI**
  - Enable cross build: `crossScalaVersions := Seq(2.12.20, 3.8.4)`
  - Set bytecode targets via `-release`: 11 (Scala 2.12), 17 (Scala 3)
  - Version bumps: sbt 2 target → `2.0.0`, Scala 3 → `3.8.4`, sbt 1 build → `1.12.11`
  - CI: Java 17, `actions/checkout@v6`, `actions/setup-java@v5`, run `sbt +test +scripted` across both Scala axes

<sup>Written for commit 0af857116378d2703ccf740fd148f1a407e2a68a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/sbt-openapi-generator/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

